### PR TITLE
refactor(cli): turn off the default auto-install-dependencies

### DIFF
--- a/packages/check-update/package.json
+++ b/packages/check-update/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vrn-deco/cli-check-update",
-  "version": "1.2.0",
+  "version": "1.2.1",
   "description": "@vrn-deco/cli-check-update",
   "author": "Cphayim <i@cphayim.me>",
   "homepage": "https://github.com/vrn-deco/cli#readme",

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vrn-deco/cli",
-  "version": "1.2.0",
+  "version": "1.2.1",
   "description": "⚙️ Project scaffolding with command line tools. 🛠",
   "author": "Cphayim <i@cphayim.me>",
   "homepage": "https://github.com/vrn-deco/cli#readme",

--- a/packages/command-boilerplate/package.json
+++ b/packages/command-boilerplate/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vrn-deco/cli-command-boilerplate",
-  "version": "1.2.0",
+  "version": "1.2.1",
   "description": "vrn boilerplate command",
   "author": "Cphayim <i@cphayim.me>",
   "homepage": "https://github.com/vrn-deco/cli#readme",

--- a/packages/command-boilerplate/src/create/create.command.ts
+++ b/packages/command-boilerplate/src/create/create.command.ts
@@ -54,7 +54,7 @@ createCommand
       .choices([PostGit.Retain, PostGit.Remove, PostGit.Rebuild])
       .default(PostGit.Retain),
   )
-  .option('-A, --no-auto-install-deps', 'not install, only in `package` mode will install dependencies', false)
+  .option('-i, --auto-install-deps', 'only in `package` mode will install dependencies', false)
   .action(runActionByMode)
 
 // eslint-disable-next-line @typescript-eslint/no-explicit-any

--- a/packages/command-config/package.json
+++ b/packages/command-config/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vrn-deco/cli-command-config",
-  "version": "1.2.0",
+  "version": "1.2.1",
   "description": "vrn create project boilerplate command",
   "author": "Cphayim <i@cphayim.me>",
   "homepage": "https://github.com/vrn-deco/cli#readme",

--- a/packages/command/package.json
+++ b/packages/command/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vrn-deco/cli-command",
-  "version": "1.2.0",
+  "version": "1.2.1",
   "description": "base command",
   "author": "Cphayim <i@cphayim.me>",
   "homepage": "https://github.com/vrn-deco/cli#readme",

--- a/packages/config-helper/package.json
+++ b/packages/config-helper/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vrn-deco/cli-config-helper",
-  "version": "1.2.0",
+  "version": "1.2.1",
   "description": "config maintenance",
   "author": "Cphayim <i@cphayim.me>",
   "homepage": "https://github.com/vrn-deco/cli#readme",

--- a/packages/log/package.json
+++ b/packages/log/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vrn-deco/cli-log",
-  "version": "1.2.0",
+  "version": "1.2.1",
   "description": "vrn logging tools",
   "author": "Cphayim <i@cphayim.me>",
   "homepage": "https://github.com/vrn-deco/cli#readme",

--- a/packages/npm-helper/package.json
+++ b/packages/npm-helper/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vrn-deco/cli-npm-helper",
-  "version": "1.2.0",
+  "version": "1.2.1",
   "description": "vrn npm helper",
   "author": "Cphayim <i@cphayim.me>",
   "homepage": "https://github.com/vrn-deco/cli#readme",

--- a/packages/shared/package.json
+++ b/packages/shared/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vrn-deco/cli-shared",
-  "version": "1.2.0",
+  "version": "1.2.1",
   "description": "vrn shared utils",
   "author": "Cphayim <i@cphayim.me>",
   "homepage": "https://github.com/vrn-deco/cli#readme",


### PR DESCRIPTION
resolve #19 

No longer pass autoinstall dependencies to `presetRunner` by default
Can manually enable it via the `-i` or `--auto-install-deps` options