### PR TITLE
feat(create-vrn): supports `npm init vrn`

### DIFF
--- a/create-vrn/README.md
+++ b/create-vrn/README.md
@@ -1,0 +1,19 @@
+# create-vrn
+
+[![npm package](https://badgen.net/npm/v/create-vrn)](https://www.npmjs.com/package/create-vrn)
+
+This package is a wrapper for @vrn-deco/cli, quickly create projects with full presets
+
+## Usage
+
+You don't need to pre-install any package, execute following command
+
+```sh
+npm init vrn
+```
+
+In fact it directly calls the `create` command of `@vrn-deco/cli`
+
+Note that it only supports interactive creation in `package` mode, and does not support other advanced options
+
+If you need advanced features or custom configuration, please install `@vrn-deco/cli` globally

--- a/create-vrn/index.mjs
+++ b/create-vrn/index.mjs
@@ -1,0 +1,14 @@
+#!/usr/bin/env node
+/*
+ * @Author: Cphayim
+ * this package is a wrapper for @vrn-deco/cli
+ * support `npm init vrn` or `npx create-vrn`
+ * used quick call to `vrn create` interactive `package` mode
+ */
+import { main } from '@vrn-deco/cli'
+
+// -> vrn create
+// without arguments and options
+process.argv = [...process.argv.slice(0, 2), 'create']
+
+main()

--- a/create-vrn/package.json
+++ b/create-vrn/package.json
@@ -1,0 +1,31 @@
+{
+  "name": "create-vrn",
+  "version": "1.2.2",
+  "description": "⚙️ Project scaffolding with command line tools. 🛠",
+  "author": "Cphayim <i@cphayim.me>",
+  "homepage": "https://github.com/vrn-deco/cli#readme",
+  "license": "MIT",
+  "engines": {
+    "node": "^14.13.1 || >=16.0.0"
+  },
+  "type": "module",
+  "bin": "index.mjs",
+  "main": "index.mjs",
+  "files": [
+    "index.mjs"
+  ],
+  "publishConfig": {
+    "access": "public"
+  },
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/vrn-deco/cli.git",
+    "directory": "create-vrn"
+  },
+  "bugs": {
+    "url": "https://github.com/vrn-deco/cli/issues"
+  },
+  "dependencies": {
+    "@vrn-deco/cli": "workspace:*"
+  }
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -52,6 +52,12 @@ importers:
       typescript: 4.6.3
       vitest: 0.9.2_@vitest+ui@0.7.13+c8@7.11.0
 
+  create-vrn:
+    specifiers:
+      '@vrn-deco/cli': workspace:*
+    dependencies:
+      '@vrn-deco/cli': link:../packages/cli
+
   packages/check-update:
     specifiers:
       '@types/semver': ^7.3.6

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,2 +1,3 @@
 packages:
   - 'packages/*'
+  - 'create-vrn'


### PR DESCRIPTION
Add package `create-vrn`, this package is a wrapper for @vrn-deco/cli
Support `npm init vrn` or `npx create-vrn`, used quick call to `vrn create` interactive `package` mode
