### PR TITLE
feat(cli): clear boilerplate dependency cache

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
     "test:unit": "esmo scripts/test.ts",
     "test:unit:changed": "esmo scripts/test.ts --changed main",
     "test:coverage": "esmo scripts/test.ts --coverage",
-    "lint": "eslint packages/*/src/**.ts",
+    "lint": "eslint packages/ --ext .ts --fix --ignore-path .gitignore",
     "format": "prettier --write --parser typescript \"packages/**/*.ts\"",
     "commit": "git add . && cz",
     "ch:add": "esmo scripts/changeset.ts --add",

--- a/packages/command-boilerplate/src/__tests__/clear/clear.action.spec.ts
+++ b/packages/command-boilerplate/src/__tests__/clear/clear.action.spec.ts
@@ -1,0 +1,33 @@
+import fs from 'fs-extra'
+import { afterAll, beforeAll, beforeEach, describe, expect, it, vi } from 'vitest'
+
+import { Command, runAction } from '@vrn-deco/cli-command'
+import { testShared } from '@vrn-deco/cli-shared'
+
+// mock fs.existsSync and fs.removeSync
+const fsExistsSyncSpy = vi.spyOn(fs, 'existsSync').mockImplementation(() => true)
+const fsRemoveSyncSpy = vi.spyOn(fs, 'removeSync').mockImplementation(() => void 0)
+
+const { ClearAction } = await import('../../clear/clear.action.js')
+
+beforeAll(() => {
+  testShared.injectTestEnv()
+})
+
+beforeEach(() => {
+  fsExistsSyncSpy.mockClear()
+  fsRemoveSyncSpy.mockClear()
+})
+
+afterAll(() => {
+  fsExistsSyncSpy.mockRestore()
+  fsRemoveSyncSpy.mockRestore()
+})
+
+describe('@vrn-deco/cli-command-boilerplate -> clear -> clear.action.ts', () => {
+  it('should be confirmed and cleaned cache', async () => {
+    await runAction(ClearAction)(new Command())
+    expect(fsExistsSyncSpy).toBeCalled()
+    expect(fsRemoveSyncSpy).toBeCalled()
+  })
+})

--- a/packages/command-boilerplate/src/__tests__/clear/clear.command.spec.ts
+++ b/packages/command-boilerplate/src/__tests__/clear/clear.command.spec.ts
@@ -1,0 +1,10 @@
+import { describe, expect, it } from 'vitest'
+
+import { Command } from '@vrn-deco/cli-command'
+import clearCommand from '../../clear/clear.command.js'
+
+describe('@vrn-deco/cli-command-boilerplate -> clear -> clear.command.ts', () => {
+  it('Correct exported', () => {
+    expect(clearCommand).toBeInstanceOf(Command)
+  })
+})

--- a/packages/command-boilerplate/src/clear/clear.action.ts
+++ b/packages/command-boilerplate/src/clear/clear.action.ts
@@ -1,0 +1,41 @@
+/*
+ * @Author: Cphayim
+ * @Date: 2022-05-16 11:25:16
+ * @Description: boilerplate clear command action
+ */
+import fs from 'fs-extra'
+
+import { logger } from '@vrn-deco/cli-log'
+import { Action, ActionArgs } from '@vrn-deco/cli-command'
+import { getCacheDirectory } from '../utils.js'
+
+type ClearArguments = []
+type ClearOptions = {
+  //
+}
+
+export type ClearActionArgs = ActionArgs<ClearArguments, ClearOptions>
+
+export class ClearAction extends Action<ClearArguments, ClearOptions> {
+  cacheDir = getCacheDirectory()
+
+  async initialize(): Promise<void> {
+    //
+  }
+
+  async execute(): Promise<void> {
+    await this.clearCache()
+    logger.done('Successfully cleared boilerplate package dependency cache.')
+  }
+
+  async clear(): Promise<void> {
+    //
+  }
+
+  async clearCache() {
+    if (fs.existsSync(this.cacheDir)) {
+      logger.verbose(`clear ${this.cacheDir}}`)
+      fs.removeSync(this.cacheDir)
+    }
+  }
+}

--- a/packages/command-boilerplate/src/clear/clear.command.ts
+++ b/packages/command-boilerplate/src/clear/clear.command.ts
@@ -1,0 +1,19 @@
+/*
+ * @Author: Cphayim
+ * @Date: 2022-05-16 11:21:43
+ * @Description: boilerplate clear command
+ */
+import { Command, runAction } from '@vrn-deco/cli-command'
+import { ClearAction } from './clear.action.js'
+
+const listCommand = new Command()
+export default listCommand
+
+/**
+ * e.g.
+ * vrn boi clear
+ */
+listCommand
+  .name('clear') //
+  .description('clear boilerplate package dependency cache')
+  .action(runAction(ClearAction))

--- a/packages/command-boilerplate/src/index.ts
+++ b/packages/command-boilerplate/src/index.ts
@@ -7,6 +7,7 @@ import { Command } from '@vrn-deco/cli-command'
 
 import createCommand from './create/create.command.js'
 import listCommand from './list/list.command.js'
+import clearCommand from './clear/clear.command.js'
 
 const boilerplateCommand = new Command('boilerplate')
 
@@ -15,6 +16,7 @@ boilerplateCommand
   .description('boilerplate services')
   .addCommand(createCommand) //
   .addCommand(listCommand) //
+  .addCommand(clearCommand)
 
 export default boilerplateCommand
 


### PR DESCRIPTION
When we update the package manager it may introduce incompatibilities that prevent us from using the previous `boi-package` cache, which will cause us problems with `create`.

Add a command `clear` to clear the cache when the cache is invalid.

```sh
vrn boi clear
```

